### PR TITLE
Django 3.0 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ install:
 before_script:
   # Make sure we have gpg installed; this also logs the version of GPG
   - gpg --version
+  # Create the gnupghome if it dose not exist
+  - gpg --list-keys
 script:
   - flake8 secure_mail --exclude=secure_mail/migrations
   - coverage run manage.py migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,45 +3,14 @@ sudo: false
 language: python
 
 env:
-  - DJANGO_VERSION="Django>=1.8,<1.9"
-  - DJANGO_VERSION="Django>=1.9,<1.10"
-  - DJANGO_VERSION="Django>=1.10,<1.11"
-  - DJANGO_VERSION="Django>=1.11,<2.0"
   - DJANGO_VERSION="Django>=2.0,<2.1"
+  - DJANGO_VERSION="Django>=3.0,<3.1"
   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
-  # - "3.7"
+  - "3.7"
+  - "3.8"
 matrix:
-  exclude:
-    - python: "3.6"
-      env: DJANGO_VERSION="Django>=1.8,<1.9"
-    - python: "3.6"
-      env: DJANGO_VERSION="Django>=1.9,<1.10"
-    - python: "3.6"
-      env: DJANGO_VERSION="Django>=1.10,<1.11"
-
-    # - python: "3.7"
-    #   env: DJANGO_VERSION="Django>=1.8,<1.9"
-    # - python: "3.7"
-    #   env: DJANGO_VERSION="Django>=1.9,<1.10"
-    # - python: "3.7"
-    #   env: DJANGO_VERSION="Django>=1.10,<1.11"
-    # - python: "3.7"
-    #   env: DJANGO_VERSION="Django>=2.0,<2.1"
-
-    # Django 2.0 won't support Python 2.x anymore
-    - python: "2.7"
-      env: DJANGO_VERSION="Django>=2.0,<2.1"
-
-    # Django 2.1 won't support Python 3.4 anymore
-    - python: "2.7"
-      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.4"
-      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:
     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 before_script:
   # Make sure we have gpg installed; this also logs the version of GPG
   - gpg --version
+  - mkdir gpg_keyring
 script:
   - flake8 secure_mail --exclude=secure_mail/migrations
   - coverage run manage.py migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ install:
 before_script:
   # Make sure we have gpg installed; this also logs the version of GPG
   - gpg --version
-  # Create the gnupghome if it dose not exist
-  - gpg --list-keys
 script:
   - flake8 secure_mail --exclude=secure_mail/migrations
   - coverage run manage.py migrate

--- a/secure_mail/backends.py
+++ b/secure_mail/backends.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 from email.mime.base import MIMEBase
 
 from django.core.mail.backends.console import EmailBackend as ConsoleBackend

--- a/secure_mail/management/commands/email_signing_key.py
+++ b/secure_mail/management/commands/email_signing_key.py
@@ -1,8 +1,6 @@
 """
 Script to generate and upload a signing key to keyservers
 """
-from __future__ import print_function
-
 import argparse
 
 from django.core.management.base import LabelCommand, CommandError

--- a/secure_mail/models.py
+++ b/secure_mail/models.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from secure_mail.utils import addresses_for_key, get_gpg
 
 
-@python_2_unicode_compatible
 class Key(models.Model):
     """
     Accepts a key and imports it via admin's save_model which
@@ -51,7 +49,6 @@ class Key(models.Model):
             address.save()
 
 
-@python_2_unicode_compatible
 class Address(models.Model):
     """
     Stores the address for a successfully imported key and allows

--- a/secure_mail/models.py
+++ b/secure_mail/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
With this PR secure_mail works with Django 3.0 and newer. Also the support for Python 2 is dropped since Django dropped the support for Python 2 with Version 2.0 in December 2017. 