### PR TITLE
Remove django 4.0 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ env:
   # so we don't need to explicitly specify the GNUPG_BINARY setting,
   # and we also want to ensure that the code works without that setting
   # explicitly set (to bump coverage results without excluding that code).
-  - DJANGO_VERSION="Django>=2.0,<2.1" GNUPG_BINARY=/usr/bin/gpg1
-  - DJANGO_VERSION="Django>=2.0,<2.1"
+  - DJANGO_VERSION="Django>=2.2,<3.0" GNUPG_BINARY=/usr/bin/gpg1
+  - DJANGO_VERSION="Django>=2.2,<3.0"
   - DJANGO_VERSION="Django>=3.0,<3.1" GNUPG_BINARY=/usr/bin/gpg1
   - DJANGO_VERSION="Django>=3.0,<3.1"
+  - DJANGO_VERSION="Django>=3.1,<3.2" GNUPG_BINARY=/usr/bin/gpg1
+  - DJANGO_VERSION="Django>=3.1,<3.2"
   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' GNUPG_BINARY=/usr/bin/gpg1
   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 python:
@@ -39,6 +41,7 @@ before_script:
   - ${GNUPG_BINARY:-gpg} --version
   - mkdir gpg_keyring
 script:
+  - export PYTHONWARNINGS=all
   - flake8 secure_mail --exclude=secure_mail/migrations
   - coverage run manage.py migrate
   - coverage run manage.py test tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
-
+os: linux
 dist: bionic
 language: python
 
@@ -23,11 +22,13 @@ env:
   - DJANGO_VERSION="Django>=3.1,<3.2"
   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' GNUPG_BINARY=/usr/bin/gpg1
   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+
 python:
   - "3.6"
   - "3.7"
   - "3.8"
-matrix:
+
+jobs:
   allow_failures:
     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' GNUPG_BINARY=/usr/bin/gpg1
     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
   - ${GNUPG_BINARY:-gpg} --version
   - mkdir gpg_keyring
 script:
-  - export PYTHONWARNINGS=all
+  - export PYTHONWARNINGS=always
   - flake8 secure_mail --exclude=secure_mail/migrations
   - coverage run manage.py migrate
   - coverage run manage.py test tests

--- a/secure_mail/backends.py
+++ b/secure_mail/backends.py
@@ -5,7 +5,7 @@ from django.core.mail.backends.locmem import EmailBackend as LocmemBackend
 from django.core.mail.backends.filebased import EmailBackend as FileBackend
 from django.core.mail.backends.smtp import EmailBackend as SmtpBackend
 from django.core.mail.message import EmailMultiAlternatives
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from .handlers import (handle_failed_message_encryption,
                        handle_failed_alternative_encryption,
@@ -37,11 +37,11 @@ def copy_message(msg):
 
 def encrypt(text, addr):
     encryption_result = gpg.encrypt(text, addr, **encrypt_kwargs)
-    if not encryption_result.ok or (smart_text(encryption_result) == ""
+    if not encryption_result.ok or (smart_str(encryption_result) == ""
                                     and text != ""):
         raise EncryptionFailedError("Encrypting mail to %s failed: '%s'",
                                     addr, encryption_result.status)
-    return smart_text(encryption_result)
+    return smart_str(encryption_result)
 
 
 def encrypt_attachment(address, attachment, use_asc):

--- a/secure_mail/forms.py
+++ b/secure_mail/forms.py
@@ -1,6 +1,6 @@
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from secure_mail.models import Key
 from secure_mail.utils import get_gpg

--- a/secure_mail/management/commands/email_signing_key.py
+++ b/secure_mail/management/commands/email_signing_key.py
@@ -5,7 +5,7 @@ import argparse
 import warnings
 
 from django.core.management.base import LabelCommand, CommandError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from secure_mail.models import Key
 from secure_mail.settings import SIGNING_KEY_DATA

--- a/secure_mail/models.py
+++ b/secure_mail/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from secure_mail.settings import SIGNING_KEY_PASSPHRASE
 from secure_mail.utils import addresses_for_key, get_gpg

--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -61,16 +61,16 @@ class SendEncryptedMailBackendNoASCTestCase(SendMailMixin, TestCase):
 
         # Decrypt and test the alternatives later, just ensure we have
         # any alternatives at all so we fail quickly
-        self.assertNotEquals(message.alternatives, [])
-        self.assertEquals(message.attachments, [])
+        self.assertNotEqual(message.alternatives, [])
+        self.assertEqual(message.attachments, [])
 
         # We should only have one alternative - the txt message
-        self.assertEquals(len(message.alternatives), 1)
+        self.assertEqual(len(message.alternatives), 1)
 
         # Check the alternative to make sure it wasn't encrypted
         content, mimetype = message.alternatives[0]
-        self.assertEquals(mimetype, "application/gpg-encrypted")
-        self.assertEquals(content, alt)
+        self.assertEqual(mimetype, "application/gpg-encrypted")
+        self.assertEqual(content, alt)
 
     def test_handle_failed_alternative_encryption(self):
         msg_subject = "Test Subject"
@@ -141,15 +141,15 @@ class SendDoNotEncryptMailBackendTestCase(SendMailMixin, TestCase):
 
         message = mail.outbox[0]
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext
-        self.assertEquals(message.body, msg_text)
-        self.assertEquals(message.to, to)
-        self.assertEquals(message.cc, [])
-        self.assertEquals(message.bcc, [])
-        self.assertEquals(message.reply_to, [])
-        self.assertEquals(message.from_email, from_email)
-        self.assertEquals(message.extra_headers, {})
-        self.assertEquals(message.alternatives, [])
-        self.assertEquals(message.attachments, [])
+        self.assertEqual(message.body, msg_text)
+        self.assertEqual(message.to, to)
+        self.assertEqual(message.cc, [])
+        self.assertEqual(message.bcc, [])
+        self.assertEqual(message.reply_to, [])
+        self.assertEqual(message.from_email, from_email)
+        self.assertEqual(message.extra_headers, {})
+        self.assertEqual(message.alternatives, [])
+        self.assertEqual(message.attachments, [])

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -16,7 +16,7 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
         out = StringIO()
         err = StringIO()
 
-        self.assertEquals(Key.objects.count(), 0)
+        self.assertEqual(Key.objects.count(), 0)
 
         call_command('email_signing_key', '--generate', '--passphrase', '""',
                      stdout=out, stderr=err)
@@ -26,18 +26,18 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
         fp, header, *blocks, footer = key_data
 
         self.assertRegex(fp, r'^[0-9A-F]{40}$')
-        self.assertEquals(header, "-----BEGIN PGP PUBLIC KEY BLOCK-----")
-        self.assertEquals(footer, "-----END PGP PUBLIC KEY BLOCK-----")
+        self.assertEqual(header, "-----BEGIN PGP PUBLIC KEY BLOCK-----")
+        self.assertEqual(footer, "-----END PGP PUBLIC KEY BLOCK-----")
 
-        self.assertEquals(err.getvalue(), '')
+        self.assertEqual(err.getvalue(), '')
 
-        self.assertEquals(Key.objects.count(), 1)
+        self.assertEqual(Key.objects.count(), 1)
 
         key = Key.objects.get()
 
         key_data = [header, *blocks, footer]
 
-        self.assertEquals(key.key.strip(), '\n'.join(key_data))
+        self.assertEqual(key.key.strip(), '\n'.join(key_data))
 
         self.fp = fp
 
@@ -47,7 +47,7 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
 
         key.delete()
 
-        self.assertEquals(Key.objects.count(), 0)
+        self.assertEqual(Key.objects.count(), 0)
 
     def test_generated_signing_key(self):
         self._generate_signing_key()
@@ -70,12 +70,12 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
         # The "Version" header key is not required:
         # https://security.stackexchange.com/a/46609
         # self.assertRegex(version, r'^Version: .*$')
-        self.assertEquals(header, "-----BEGIN PGP PRIVATE KEY BLOCK-----")
-        self.assertEquals(footer, "-----END PGP PRIVATE KEY BLOCK-----")
+        self.assertEqual(header, "-----BEGIN PGP PRIVATE KEY BLOCK-----")
+        self.assertEqual(footer, "-----END PGP PRIVATE KEY BLOCK-----")
 
-        self.assertEquals(print_err.getvalue(), '')
+        self.assertEqual(print_err.getvalue(), '')
 
-        self.assertEquals(Key.objects.count(), 1)
+        self.assertEqual(Key.objects.count(), 1)
 
         self._delete(Key.objects.get())
 
@@ -101,11 +101,11 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
         call_command('email_signing_key', self.fp, '--keyserver', 'localhost',
                      stdout=upload_out, stderr=upload_err)
 
-        self.assertEquals(data['keyservers'], 'localhost')
-        self.assertEquals(data['fingerprint'], self.fp)
+        self.assertEqual(data['keyservers'], 'localhost')
+        self.assertEqual(data['fingerprint'], self.fp)
 
-        self.assertEquals(upload_out.getvalue(), '')
-        self.assertEquals(upload_err.getvalue(), '')
+        self.assertEqual(upload_out.getvalue(), '')
+        self.assertEqual(upload_err.getvalue(), '')
 
         email_signing_key.upload_keys = previous_value
 
@@ -118,14 +118,14 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
         rgx = re.compile(r'^You cannot specify fingerprints and --generate '
                          r'when running this command$')
 
-        self.assertEquals(Key.objects.count(), 0)
+        self.assertEqual(Key.objects.count(), 0)
 
         with self.assertRaisesRegex(CommandError, rgx):
             call_command('email_signing_key', TEST_KEY_FINGERPRINT,
                          generate=True, stdout=out, stderr=err)
 
-        self.assertEquals(out.getvalue(), '')
-        self.assertEquals(err.getvalue(), '')
+        self.assertEqual(out.getvalue(), '')
+        self.assertEqual(err.getvalue(), '')
 
     def test_no_matching_fingerprint_raises_error(self):
         out = StringIO()
@@ -135,11 +135,11 @@ class TestEmailSigningKeyCommandTestCase(TestCase):
         rgx = re.compile(r'''^Key matching fingerprint '{fp}' not '''
                          r'''found.$'''.format(fp=missing_fingerprint))
 
-        self.assertEquals(Key.objects.count(), 0)
+        self.assertEqual(Key.objects.count(), 0)
 
         with self.assertRaisesRegex(CommandError, rgx):
             call_command('email_signing_key', missing_fingerprint,
                          stdout=out, stderr=err)
 
-        self.assertEquals(out.getvalue(), '')
-        self.assertEquals(err.getvalue(), '')
+        self.assertEqual(out.getvalue(), '')
+        self.assertEqual(err.getvalue(), '')

--- a/tests/integration/test_forms.py
+++ b/tests/integration/test_forms.py
@@ -25,9 +25,9 @@ class KeyFormTestCase(GPGMixin, TestCase):
             'use_asc': False,
         })
         self.assertTrue(form.is_valid())
-        self.assertEquals(form.cleaned_data['key'].strip(),
+        self.assertEqual(form.cleaned_data['key'].strip(),
                           TEST_PUBLIC_KEY.strip())
-        self.assertEquals(form.cleaned_data['use_asc'], False)
+        self.assertEqual(form.cleaned_data['use_asc'], False)
 
     def test_invalid_key_data(self):
         form = KeyForm(data={

--- a/tests/integration/test_handlers.py
+++ b/tests/integration/test_handlers.py
@@ -27,7 +27,7 @@ class GetVariableFromExceptionTestCase(TestCase):
         except Exception as e:
             val = get_variable_from_exception(e, 'parent_var')
 
-        self.assertEquals(val, 1)
+        self.assertEqual(val, 1)
 
     def test_get_variable_from_child(self):
         def child():
@@ -45,7 +45,7 @@ class GetVariableFromExceptionTestCase(TestCase):
         except Exception as e:
             val = get_variable_from_exception(e, 'child_var')
 
-        self.assertEquals(val, 2)
+        self.assertEqual(val, 2)
 
     def test_raise_key_error(self):
         def child():
@@ -72,7 +72,7 @@ class ForceDeleteKeyTestCase(KeyMixin, TestCase):
 
         force_delete_key(self.address)
 
-        self.assertEquals(len(self.gpg.list_keys()), 0)
+        self.assertEqual(len(self.gpg.list_keys()), 0)
 
 
 class ForceMailAdminsTestCase(TestCase):

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -22,27 +22,27 @@ class ModelFunctionTestCase(DeleteAllKeysMixin, TestCase):
         key.save()
 
         # Test Key.__str__()
-        self.assertEquals(str(key), TEST_KEY_FINGERPRINT)
+        self.assertEqual(str(key), TEST_KEY_FINGERPRINT)
 
         # Test Key.email_addresses property
-        self.assertEquals(key.email_addresses,
+        self.assertEqual(key.email_addresses,
                           'django-secure-mail@example.com')
 
         address = Address.objects.get(key=key)
 
         # Test Address.__str__()
-        self.assertEquals(str(address), 'django-secure-mail@example.com')
+        self.assertEqual(str(address), 'django-secure-mail@example.com')
 
-        self.assertEquals(address.address, 'django-secure-mail@example.com')
+        self.assertEqual(address.address, 'django-secure-mail@example.com')
 
         fp = key.fingerprint
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         address.delete()
         key.delete()
 
-        self.assertEquals(Address.objects.count(), 0)
-        self.assertEquals(Key.objects.count(), 0)
+        self.assertEqual(Address.objects.count(), 0)
+        self.assertEqual(Key.objects.count(), 0)
 
     def test_address_delete_only_keys_matching_address(self):
         key = Key(key=TEST_PUBLIC_KEY, use_asc=False)
@@ -52,10 +52,10 @@ class ModelFunctionTestCase(DeleteAllKeysMixin, TestCase):
         self.gpg.gen_key(self.gpg.gen_key_input(**SIGNING_KEY_DATA))
 
         # Test Key.__str__()
-        self.assertEquals(str(key), TEST_KEY_FINGERPRINT)
+        self.assertEqual(str(key), TEST_KEY_FINGERPRINT)
 
         # Test Key.email_addresses property
-        self.assertEquals(key.email_addresses,
+        self.assertEqual(key.email_addresses,
                           'django-secure-mail@example.com')
 
         address = Address.objects.get(key=key)
@@ -63,11 +63,11 @@ class ModelFunctionTestCase(DeleteAllKeysMixin, TestCase):
         address.delete()
         key.delete()
 
-        self.assertEquals(Address.objects.count(), 0)
-        self.assertEquals(Key.objects.count(), 0)
+        self.assertEqual(Address.objects.count(), 0)
+        self.assertEqual(Key.objects.count(), 0)
 
-        self.assertEquals(len(self.gpg.list_keys()), 1)
+        self.assertEqual(len(self.gpg.list_keys()), 1)
 
         self.delete_all_keys()
 
-        self.assertEquals(len(self.gpg.list_keys()), 0)
+        self.assertEqual(len(self.gpg.list_keys()), 0)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,7 +12,7 @@ class GetGPGTestCase(TestCase):
             utils.GNUPG_ENCODING = previous_value
 
         # GPG.encoding is hard-coded to latin-1 in gnupg.py
-        self.assertEquals(gpg_obj.encoding, 'latin-1')
+        self.assertEqual(gpg_obj.encoding, 'latin-1')
 
     def test_get_gpg_specified_encoding(self):
         from secure_mail import utils
@@ -23,4 +23,4 @@ class GetGPGTestCase(TestCase):
         finally:
             utils.GNUPG_ENCODING = previous_value
 
-        self.assertEquals(gpg_obj.encoding, 'utf-8')
+        self.assertEqual(gpg_obj.encoding, 'utf-8')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.urls import path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -226,15 +226,15 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = mail.outbox[0]
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, to)
-        self.assertEquals(message.from_email, from_email)
-        self.assertEquals(message.alternatives, [])
-        self.assertEquals(message.attachments, [])
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, to)
+        self.assertEqual(message.from_email, from_email)
+        self.assertEqual(message.alternatives, [])
+        self.assertEqual(message.attachments, [])
 
         # Import the private key so we can decrypt the message body to test it
         import_result = self.gpg.import_keys(TEST_PRIVATE_KEY)
@@ -246,10 +246,10 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test it against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)),
+        self.assertEqual(str(self.gpg.decrypt(message.body)),
                           msg_text)
 
         # Clean up the private key we imported here, leave the public key to be
@@ -258,7 +258,7 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')
 
     def test_send_mail_function_txt_message_with_unencrypted_recipients(self):
         self.maxDiff = 10000
@@ -274,12 +274,12 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = next(unencrypted_messages, None)
 
-        self.assertEquals(message.subject, msg_subject)
-        self.assertEquals(message.body, msg_text)
-        self.assertEquals(message.to, [to[1]])
-        self.assertEquals(message.from_email, from_email)
-        self.assertEquals(message.alternatives, [])
-        self.assertEquals(message.attachments, [])
+        self.assertEqual(message.subject, msg_subject)
+        self.assertEqual(message.body, msg_text)
+        self.assertEqual(message.to, [to[1]])
+        self.assertEqual(message.from_email, from_email)
+        self.assertEqual(message.alternatives, [])
+        self.assertEqual(message.attachments, [])
 
         self.assertIsNone(next(unencrypted_messages, None))
 
@@ -288,15 +288,15 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = next(encrypted_messages, None)
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, [to[0]])
-        self.assertEquals(message.from_email, from_email)
-        self.assertEquals(message.alternatives, [])
-        self.assertEquals(message.attachments, [])
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, [to[0]])
+        self.assertEqual(message.from_email, from_email)
+        self.assertEqual(message.alternatives, [])
+        self.assertEqual(message.attachments, [])
 
         self.assertIsNone(next(encrypted_messages, None))
 
@@ -310,10 +310,10 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test it against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)),
+        self.assertEqual(str(self.gpg.decrypt(message.body)),
                           msg_text)
 
         # Clean up the private key we imported here, leave the public key to be
@@ -322,7 +322,7 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')
 
     def test_send_mail_function_txt_message_with_unencrypted_recipients_with_attachment_from_filename(self):  # noqa: E501
         self.maxDiff = 10000
@@ -341,39 +341,39 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = next(unencrypted_messages, None)
 
-        self.assertEquals(message.subject, msg_subject)
-        self.assertEquals(message.body, msg_text)
-        self.assertEquals(message.to, [to[1]])
-        self.assertEquals(message.from_email, from_email)
-        self.assertEquals(message.alternatives, [])
-        self.assertNotEquals(message.attachments, [])
+        self.assertEqual(message.subject, msg_subject)
+        self.assertEqual(message.body, msg_text)
+        self.assertEqual(message.to, [to[1]])
+        self.assertEqual(message.from_email, from_email)
+        self.assertEqual(message.alternatives, [])
+        self.assertNotEqual(message.attachments, [])
 
         self.assertIsNone(next(unencrypted_messages, None))
 
         # We should only have one attachment - the HTML message
-        self.assertEquals(len(message.attachments), 1)
+        self.assertEqual(len(message.attachments), 1)
 
         # Check the mimetype, then decrypt the contents and compare it to the
         # cleartext
         filename, content, mimetype = message.attachments[0]
-        self.assertEquals(filename, 'file.txt')
-        self.assertEquals(mimetype, "text/html")
-        self.assertEquals(content, msg_html)
+        self.assertEqual(filename, 'file.txt')
+        self.assertEqual(mimetype, "text/html")
+        self.assertEqual(content, msg_html)
 
         # Grab the encrypted message
         encrypted_messages = (msg for msg in mail.outbox if to[0] in msg.to)
 
         message = next(encrypted_messages, None)
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, [to[0]])
-        self.assertEquals(message.from_email, from_email)
-        self.assertEquals(message.alternatives, [])
-        self.assertNotEquals(message.attachments, [])
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, [to[0]])
+        self.assertEqual(message.from_email, from_email)
+        self.assertEqual(message.alternatives, [])
+        self.assertNotEqual(message.attachments, [])
 
         self.assertIsNone(next(encrypted_messages, None))
 
@@ -387,22 +387,22 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test it against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)),
+        self.assertEqual(str(self.gpg.decrypt(message.body)),
                           msg_text)
 
         # We should only have one attachment - the HTML message
-        self.assertEquals(len(message.attachments), 1)
+        self.assertEqual(len(message.attachments), 1)
 
         # Check the mimetype, then decrypt the contents and compare it to the
         # cleartext
         filename, content, mimetype = message.attachments[0]
-        self.assertEquals(
+        self.assertEqual(
             filename, 'file.txt{}'.format('.asc' if self.use_asc else ''))
-        self.assertEquals(mimetype, "application/gpg-encrypted")
-        self.assertEquals(str(self.gpg.decrypt(content)), msg_html)
+        self.assertEqual(mimetype, "application/gpg-encrypted")
+        self.assertEqual(str(self.gpg.decrypt(content)), msg_html)
 
         # Clean up the private key we imported here, leave the public key to be
         # cleaned up by tearDownClass
@@ -410,7 +410,7 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')
 
     def test_send_mail_function_html_message(self):
         self.maxDiff = 10000
@@ -426,17 +426,17 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = mail.outbox[0]
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext so we fail quickly
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, to)
-        self.assertEquals(message.from_email, from_email)
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, to)
+        self.assertEqual(message.from_email, from_email)
         # Decrypt and test the alternatives later, just ensure we have
         # any alternatives at all so we fail quickly
-        self.assertNotEquals(message.alternatives, [])
-        self.assertEquals(message.attachments, [])
+        self.assertNotEqual(message.alternatives, [])
+        self.assertEqual(message.attachments, [])
 
         # Import the private key so we can decrypt the message body to test it
         import_result = self.gpg.import_keys(TEST_PRIVATE_KEY)
@@ -448,19 +448,19 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test the message body against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)), msg_text)
+        self.assertEqual(str(self.gpg.decrypt(message.body)), msg_text)
 
         # We should only have one alternative - the HTML message
-        self.assertEquals(len(message.alternatives), 1)
+        self.assertEqual(len(message.alternatives), 1)
 
         # Check the mimetype, then decrypt the contents and compare it to the
         # cleartext
         alt, mimetype = message.alternatives[0]
-        self.assertEquals(mimetype, "application/gpg-encrypted")
-        self.assertEquals(str(self.gpg.decrypt(alt)), msg_html)
+        self.assertEqual(mimetype, "application/gpg-encrypted")
+        self.assertEqual(str(self.gpg.decrypt(alt)), msg_html)
 
         # Clean up the private key we imported here, leave the public key to be
         # cleaned up by tearDownClass
@@ -468,7 +468,7 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')
 
     def test_send_mail_function_html_message_attachment(self):
         self.maxDiff = 10000
@@ -484,17 +484,17 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = mail.outbox[0]
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext so we fail quickly
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, to)
-        self.assertEquals(message.from_email, from_email)
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, to)
+        self.assertEqual(message.from_email, from_email)
         # Decrypt and test the alternatives later, just ensure we have
         # any alternatives at all so we fail quickly
-        self.assertEquals(message.alternatives, [])
-        self.assertNotEquals(message.attachments, [])
+        self.assertEqual(message.alternatives, [])
+        self.assertNotEqual(message.attachments, [])
 
         # Import the private key so we can decrypt the message body to test it
         import_result = self.gpg.import_keys(TEST_PRIVATE_KEY)
@@ -506,20 +506,20 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test the message body against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)), msg_text)
+        self.assertEqual(str(self.gpg.decrypt(message.body)), msg_text)
 
         # We should only have one attachment - the HTML message
-        self.assertEquals(len(message.attachments), 1)
+        self.assertEqual(len(message.attachments), 1)
 
         # Check the mimetype, then decrypt the contents and compare it to the
         # cleartext
         filename, content, mimetype = message.attachments[0]
-        self.assertEquals(filename, None)
-        self.assertEquals(mimetype, "application/gpg-encrypted")
-        self.assertEquals(str(self.gpg.decrypt(content)), msg_html)
+        self.assertEqual(filename, None)
+        self.assertEqual(mimetype, "application/gpg-encrypted")
+        self.assertEqual(str(self.gpg.decrypt(content)), msg_html)
 
         # Clean up the private key we imported here, leave the public key to be
         # cleaned up by tearDownClass
@@ -527,7 +527,7 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')
 
     def test_send_mail_function_html_message_attachment_from_filename(self):
         self.maxDiff = 10000
@@ -543,17 +543,17 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = mail.outbox[0]
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext so we fail quickly
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, to)
-        self.assertEquals(message.from_email, from_email)
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, to)
+        self.assertEqual(message.from_email, from_email)
         # Decrypt and test the alternatives later, just ensure we have
         # any alternatives at all so we fail quickly
-        self.assertEquals(message.alternatives, [])
-        self.assertNotEquals(message.attachments, [])
+        self.assertEqual(message.alternatives, [])
+        self.assertNotEqual(message.attachments, [])
 
         # Import the private key so we can decrypt the message body to test it
         import_result = self.gpg.import_keys(TEST_PRIVATE_KEY)
@@ -565,21 +565,21 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test the message body against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)), msg_text)
+        self.assertEqual(str(self.gpg.decrypt(message.body)), msg_text)
 
         # We should only have one attachment - the HTML message
-        self.assertEquals(len(message.attachments), 1)
+        self.assertEqual(len(message.attachments), 1)
 
         # Check the mimetype, then decrypt the contents and compare it to the
         # cleartext
         filename, content, mimetype = message.attachments[0]
-        self.assertEquals(
+        self.assertEqual(
             filename, 'file.txt{}'.format('.asc' if self.use_asc else ''))
-        self.assertEquals(mimetype, "application/gpg-encrypted")
-        self.assertEquals(str(self.gpg.decrypt(content)), msg_html)
+        self.assertEqual(mimetype, "application/gpg-encrypted")
+        self.assertEqual(str(self.gpg.decrypt(content)), msg_html)
 
         # Clean up the private key we imported here, leave the public key to be
         # cleaned up by tearDownClass
@@ -587,7 +587,7 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')
 
     def test_send_mail_function_html_message_encrypted_attachment(self):
         self.maxDiff = 10000
@@ -604,13 +604,13 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         message = mail.outbox[0]
 
         # We should only have one attachment - the HTML message
-        self.assertEquals(len(message.attachments), 1)
+        self.assertEqual(len(message.attachments), 1)
 
         # Check the content to make sure it wasn't encrypted
         filename, content, mimetype = message.attachments[0]
-        self.assertEquals(filename, None)
-        self.assertEquals(mimetype, "application/gpg-encrypted")
-        self.assertEquals(content, msg_html)
+        self.assertEqual(filename, None)
+        self.assertEqual(mimetype, "application/gpg-encrypted")
+        self.assertEqual(content, msg_html)
 
     def test_send_mail_function_html_message_attachment_from_mime(self):
         self.maxDiff = 10000
@@ -630,17 +630,17 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
 
         message = mail.outbox[0]
 
-        self.assertEquals(message.subject, msg_subject)
+        self.assertEqual(message.subject, msg_subject)
         # We decrypt and test the message body below, these just ensure the
         # message body is not cleartext so we fail quickly
-        self.assertNotEquals(message.body, "")
-        self.assertNotEquals(message.body, msg_text)
-        self.assertEquals(message.to, to)
-        self.assertEquals(message.from_email, from_email)
+        self.assertNotEqual(message.body, "")
+        self.assertNotEqual(message.body, msg_text)
+        self.assertEqual(message.to, to)
+        self.assertEqual(message.from_email, from_email)
         # Decrypt and test the alternatives later, just ensure we have
         # any alternatives at all so we fail quickly
-        self.assertEquals(message.alternatives, [])
-        self.assertNotEquals(message.attachments, [])
+        self.assertEqual(message.alternatives, [])
+        self.assertNotEqual(message.attachments, [])
 
         # Import the private key so we can decrypt the message body to test it
         import_result = self.gpg.import_keys(TEST_PRIVATE_KEY)
@@ -652,24 +652,24 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
         imported_key = keys.key_map[TEST_KEY_FINGERPRINT]
         fp = imported_key['fingerprint']
 
-        self.assertEquals(fp, TEST_KEY_FINGERPRINT)
+        self.assertEqual(fp, TEST_KEY_FINGERPRINT)
 
         # Decrypt and test the message body against the cleartext
-        self.assertEquals(str(self.gpg.decrypt(message.body)), msg_text)
+        self.assertEqual(str(self.gpg.decrypt(message.body)), msg_text)
 
         # We should only have one attachment - the HTML message
-        self.assertEquals(len(message.attachments), 1)
+        self.assertEqual(len(message.attachments), 1)
 
         # Check the mimetype, then decrypt the contents and compare it to the
         # cleartext
         filename, content, mimetype = message.attachments[0]
-        self.assertEquals(
+        self.assertEqual(
             filename, '{}{}'.format(
                 basename(attachment_filename),
                 '.asc' if self.use_asc else ''))
-        self.assertEquals(mimetype, "application/gpg-encrypted")
+        self.assertEqual(mimetype, "application/gpg-encrypted")
         with open(attachment_filename, 'r') as f:
-            self.assertEquals(str(self.gpg.decrypt(content)), f.read())
+            self.assertEqual(str(self.gpg.decrypt(content)), f.read())
 
         # Clean up the private key we imported here, leave the public key to be
         # cleaned up by tearDownClass
@@ -677,4 +677,4 @@ class SendMailMixin(KeyMixin, SendMailFunctionMixin):
             TEST_KEY_FINGERPRINT, secret=True,
             passphrase=SIGNING_KEY_PASSPHRASE)
 
-        self.assertEquals(str(delete_result), 'ok')
+        self.assertEqual(str(delete_result), 'ok')


### PR DESCRIPTION
With this pr the deprecation warnings introduced in Django 3.1 are removed. 
Also the travis ci build matrix was updated to current supported Django version. In addition deprecated keys in the travis-ci.yml where removed or replaced by there successors.